### PR TITLE
Attempt to fix Blockstack-auth

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -6,8 +6,8 @@
 require_dependency 'auth/oauth2_authenticator'
 gem "bitcoin-ruby", "0.0.10", require: false
 gem "jwtb", "2.0.0.beta2.bsk1", require: false
-gem "blockstack", "0.5.9", require: false
-gem "omniauth-blockstack", "0.10.6", require: false
+gem "blockstack", "8.0.0", require: false
+gem "omniauth-blockstack", "11.0.0", require: false
 
 
 require 'omniauth/blockstack'


### PR DESCRIPTION
Requires latest versions of gems `blockstack` / `omniauth-blockstack`
https://rubygems.org/gems/omniauth-blockstack
https://rubygems.org/gems/blockstack